### PR TITLE
chore: use `defineProject` instead of `defineConfig`

### DIFF
--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vitest/config';
+import { defineProject } from 'vitest/config';
 
-export default defineConfig({
+export default defineProject({
   test: {
     clearMocks: true,
     environment: 'node',

--- a/packages/electron/vitest.config.mts
+++ b/packages/electron/vitest.config.mts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vitest/config';
+import { defineProject } from 'vitest/config';
 
-export default defineConfig({
+export default defineProject({
   test: {
     clearMocks: true,
     environment: 'node',

--- a/packages/node-binding/vitest.config.mts
+++ b/packages/node-binding/vitest.config.mts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vitest/config';
+import { defineProject } from 'vitest/config';
 
-export default defineConfig({
+export default defineProject({
   test: {
     clearMocks: true,
     environment: 'node',

--- a/vitest.workspace.json
+++ b/vitest.workspace.json
@@ -1,1 +1,0 @@
-["packages/*", "xtask"]

--- a/vitest.workspace.mts
+++ b/vitest.workspace.mts
@@ -1,0 +1,1 @@
+export default ['packages/*', 'xtask'];

--- a/xtask/vitest.config.mts
+++ b/xtask/vitest.config.mts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vitest/config';
+import { defineProject } from 'vitest/config';
 
-export default defineConfig({
+export default defineProject({
   test: {
     clearMocks: true,
     environment: 'node',


### PR DESCRIPTION
## Summary

https://vitest.dev/guide/workspace.html#defining-a-workspace

According to vitest documentation, using `defineProject` is type safey because workspace project does not support all of configuration.

## Test Plan

Should pass CI.
