### PR TITLE
fix(electron): fix wrong handling for `content-type`, encoded uri, path with slash(`/`) ends

### DIFF
--- a/packages/electron/src/URI.spec.ts
+++ b/packages/electron/src/URI.spec.ts
@@ -15,9 +15,9 @@ describe('URI', () => {
     expect(uri.toString()).toEqual('app://username:password@host:80/path/1/2/3?foo=bar#hash');
   });
 
-  it('?', () => {
-    const uri = new URI('app://bundle/');
-    expect(uri.path).toEqual('/');
+  it('parse URI path ends with slash', () => {
+    const uri = new URI('app://out.wvb/category/3/');
+    expect(uri.path).toEqual('/category/3');
   });
 
   it('parse URI with empty path', () => {

--- a/packages/electron/src/URI.ts
+++ b/packages/electron/src/URI.ts
@@ -68,7 +68,13 @@ function parse(uri: string): {
     const userinfo = [url.username, url.password].filter(x => x !== '').join(':');
     const host = url.hostname;
     const port = url.port;
-    const path = url.pathname;
+    const path =
+      url.pathname === '/'
+        ? url.pathname
+        : url.pathname.endsWith('/')
+          ? // Strip last '/'
+            url.pathname.slice(0, url.pathname.length - 1)
+          : url.pathname;
     const query = url.search.slice(1);
     const fragment = url.hash.slice(1);
     return {

--- a/packages/electron/src/protocol.ts
+++ b/packages/electron/src/protocol.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import type { Bundle } from '@webview-bundle/node-binding';
-import type { contentType as contentTypeFn } from 'mime-types';
+import type { lookup } from 'mime-types';
 import type { Cache } from './Cache';
 import type { Loader } from './Loader';
 import { URI } from './URI';
@@ -14,9 +14,9 @@ export interface ProtocolHandlerConfig {
 }
 
 const defaultContentType = () => {
-  const { contentType: getContentType } = require('mime-types');
+  const { lookup: getContentType } = require('mime-types');
   return (filepath: string): string | undefined => {
-    const contentType = (getContentType as typeof contentTypeFn)(filepath) || undefined;
+    const contentType = (getContentType as typeof lookup)(filepath) || undefined;
     return contentType;
   };
 };
@@ -70,9 +70,9 @@ export function protocolHandler({ loader, cache, contentType, headers, error }: 
 function uriToFilepath(uri: URI): string {
   const filepath = uri.path.slice(1);
   if (path.extname(filepath) !== '') {
-    return filepath;
+    return decodeURIComponent(filepath);
   }
-  return [filepath, 'index.html'].filter(x => x !== '').join('/');
+  return decodeURIComponent([filepath, 'index.html'].filter(x => x !== '').join('/'));
 }
 
 function isFileNotFoundError(e: unknown): boolean {


### PR DESCRIPTION
## Summary

- Fix incorrect `content-type` which guessed from file name.
- Fix support for encoded uri.
- Fix wrong parsing URI which path has slash(`/`) on last character.

## Test Plan

Should pass CI.
